### PR TITLE
Use GitHub Container Registry

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -8,8 +8,8 @@ on:
   workflow_dispatch:
 
 env:
-  REGISTRY: docker.io
-  IMAGE_NAME: ${{ secrets.DOCKERHUB_USERNAME }}/honeybeepf-llm
+  REGISTRY: ghcr.io
+  IMAGE_NAME: honeybee-studio/honeybeepf-llm
 
 jobs:
   lint:
@@ -79,6 +79,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -89,11 +90,12 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Log in to Docker Hub
+      - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract Docker metadata (tags, labels)
         id: meta

--- a/charts/honeybeepf-llm/values.yaml
+++ b/charts/honeybeepf-llm/values.yaml
@@ -2,7 +2,7 @@ nameOverride: ""
 fullnameOverride: ""
 
 image:
-  repository: "docker.io/dorokrok/honeybeepf-llm"
+  repository: "ghcr.io/honeybee-studio/honeybeepf-llm"
   tag: "latest"
   pullPolicy: Always
 imagePullSecrets: [] 


### PR DESCRIPTION
## 🚀 **Pull Request**

### **Summary**

- Switched Docker image registry from Docker Hub to GitHub Container Registry (ghcr.io).
- Updated CI workflow to authenticate with `GITHUB_TOKEN` instead of Docker Hub credentials.
- Updated Helm chart default image repository to `ghcr.io/honeybee-studio/honeybeepf-llm`.

---

### **Additional Notes**

- `ghcr.io` is free for public repos and integrates natively with GitHub Actions.
- No additional secrets configuration required — `GITHUB_TOKEN` is automatically provided.
- Added `packages:write` permission to the Docker CI job for ghcr.io push access.

---

### **Tests**

- Verified Docker image build and push configuration in CI workflow.
- Verified Helm chart templates render correctly with updated template names.
