### PR TITLE
Add Helm chart publish to CI

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -128,3 +128,24 @@ jobs:
         run: |
           echo "Images pushed:" >> $GITHUB_STEP_SUMMARY
           echo "${{ steps.meta.outputs.tags }}" | sed 's/^/- /' >> $GITHUB_STEP_SUMMARY
+
+  helm:
+    name: Publish Helm charts
+    needs: build-and-test
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Package and push Helm chart
+        run: |
+          helm package charts/honeybeepf-llm
+          helm push honeybeepf-llm-*.tgz oci://ghcr.io/honeybee-studio
+          echo "- Pushed honeybeepf-llm" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## 🚀 **Pull Request**

### **Summary**

- Added Helm chart publish job to CI workflow.
- `honeybeepf-llm` chart is automatically packaged and pushed to `oci://ghcr.io/honeybee-studio` on main merge.

---

### **Additional Notes**

- Uses `GITHUB_TOKEN` for ghcr.io authentication, no additional secrets needed.
- Only runs on main branch (`if: github.ref == 'refs/heads/main'`).
- Install: `helm install honeybeepf-llm oci://ghcr.io/honeybee-studio/honeybeepf-llm -n honeybeepf`

---

### **Tests**

- Verified Helm chart packaging locally with `helm package`.
