### PR TITLE
Add AI tooling policy for contributors

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,6 +16,25 @@ Example:
 
 ---
 
+### **AI Assistance Disclosure**
+
+<!--
+Per our AI Tooling Policy (see CONTRIBUTING.md#ai-tooling-policy), you must
+disclose whether AI tools were used to prepare this PR. Check exactly one box.
+-->
+
+- [ ] No AI tools were used in preparing this PR.
+- [ ] AI tools were used. Briefly describe what was AI-assisted:
+      <!-- e.g., "draft of commit message", "boilerplate in X file" -->
+
+By submitting this PR, I confirm that:
+
+- [ ] I have reviewed and understand every change in this PR.
+- [ ] No AI is listed as a co-author, and no `Assisted-by:` / `Co-developed-by:` or similar commit trailers credit an AI.
+- [ ] I will respond to review comments directly, without relying on AI tools.
+
+---
+
 ### ** Tests **
 
 ---

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,33 @@ make test
 
 All checks must pass before your PR can be merged.
 
+## AI Tooling Policy
+
+This policy is adapted from the Kubernetes project's
+[AI Guidance](https://www.kubernetes.dev/docs/guide/pull-requests/#ai-guidance).
+
+Using AI tools (e.g., LLM-based code assistants) to help prepare contributions
+is acceptable, but as the author you are solely responsible for understanding
+every change you submit. The following rules apply:
+
+- **Disclose AI assistance.** If you used AI tools in preparing your PR, you
+  must state this clearly in the PR description.
+- **No AI as co-author.** Do not list AI tooling as a co-author, co-sign
+  commits using an AI tool, or use `Assisted-by:`, `Co-developed-by:`, or
+  similar commit trailers that credit an AI.
+- **No large AI-generated PRs or commit messages.** Contributions must remain
+  human-authored in substance. Large AI-generated PRs and AI-generated commit
+  messages are not allowed.
+- **Review before you submit.** Do not leave the first review of AI-generated
+  changes to the reviewers. Verify the changes yourself (code review, local
+  testing, etc.) before opening the PR. Reviewers may ask questions about any
+  AI-assisted change, and if you cannot explain why it was made, the PR will
+  be closed.
+- **Respond to review comments yourself.** When responding to review comments,
+  you must do so without relying on AI tools. Reviewers want to engage
+  directly with you, not with generated responses. If you do not engage
+  directly with reviewers, the PR will be closed.
+
 ## Development Setup
 
 ### Prerequisites


### PR DESCRIPTION
## 🚀 **Pull Request**

### **Summary**

Add an "AI Tooling Policy" section to `CONTRIBUTING.md`, adapted from the Kubernetes project's [AI Guidance](https://www.kubernetes.dev/docs/guide/pull-requests/#ai-guidance), and update the PR template so future contributors are prompted to disclose AI usage directly in their PR description.

The policy sets clear expectations for contributors who use AI tools (LLM-based code assistants, etc.) while preparing their contributions:

- **Disclose AI assistance** in the PR description
- **No AI as co-author** — no `Co-developed-by:` / `Assisted-by:` trailers crediting AI
- **No large AI-generated PRs or commit messages** — substance must remain human-authored
- **Review before you submit** — authors must verify AI-generated changes themselves, not leave the first review to reviewers
- **Respond to review comments yourself** — no AI-generated review responses

Files changed:
- `CONTRIBUTING.md` — new `## AI Tooling Policy` section
- `.github/pull_request_template.md` — new `### AI Assistance Disclosure` section with disclosure checkboxes and confirmation checkboxes

---

### **Additional Notes**

- **Why now**: As the project attracts more contributors, a clear policy up front prevents confusion and protects the review process from being overwhelmed by unverified AI output.
- **Why the Kubernetes text**: Kubernetes is a well-known CNCF project with an established community policy on this exact topic. Adapting their wording gives contributors familiar expectations and avoids re-inventing wheel.
- **Scope**: Documentation and PR-template-only change. No code impact.
- **Related**: This PR is intentionally split from the Apache 2.0 relicense PR to keep each change focused and reviewable.
- **Note**: The new PR template applies to PRs opened *after* this PR is merged; this PR itself is authored before the template is in place.