### PR TITLE
docs: add pre-built Grafana dashboards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,9 @@ terraform.rc
 *.log
 *.json
 *.tar
+
+# Allow Grafana dashboard JSON files under docs/grafana/
+!docs/grafana/*.json
 check-status.ps1
 install.bat
 

--- a/README.md
+++ b/README.md
@@ -130,11 +130,45 @@ kubectl port-forward -n <your-namespace> svc/honeybeepf-llm-prometheus-server 90
 
 If metrics appear in the Prometheus UI, data collection is working correctly.
 
+## 7. Grafana Dashboards
+
+Pre-built Grafana dashboards live under [`docs/grafana/`](docs/grafana/).
+
+| Dashboard | File | Focus |
+|-----------|------|-------|
+| LLM Cost Observability | [`honeybeepf-cost.json`](docs/grafana/honeybeepf-cost.json) | Requests, tokens, latency, and cost attribution by team / pod / model |
+| Security & Compliance | [`honeybeepf-security.json`](docs/grafana/honeybeepf-security.json) | File access monitoring and LLM ↔ file-access correlation |
+
+### Quick import (Grafana UI)
+
+1. Open Grafana → **Dashboards → New → Import**
+2. Upload one of the JSON files above
+3. Select your Prometheus data source when prompted
+4. Click **Import**
+
+### Automatic load via Grafana sidecar (Kubernetes)
+
+If your Grafana is configured with `sidecar.dashboards.enabled=true`, create
+a labeled ConfigMap and the sidecar will pick both dashboards up automatically:
+
+```bash
+kubectl -n monitoring create configmap honeybeepf-dashboards \
+  --from-file=docs/grafana/honeybeepf-cost.json \
+  --from-file=docs/grafana/honeybeepf-security.json
+
+kubectl -n monitoring label configmap honeybeepf-dashboards \
+  grafana_dashboard=1
+```
+
+See [`docs/grafana/README.md`](docs/grafana/README.md) for the full list
+of required metrics, template variables, and additional installation
+options.
+
 ---
 
 # Development
 
-## 7. Building
+## 8. Building
 
 ```bash
 # Standard build (without Kubernetes support)
@@ -146,7 +180,7 @@ cargo build --release --features k8s --package honeybeepf-llm
 
 > **Note:** The `k8s` feature is **not** enabled by default. When deploying to Kubernetes, always build with `--features k8s` to include pod metadata resolution. The Docker build (`Dockerfile`) already includes this flag.
 
-## 8. How to Contribute
+## 9. How to Contribute
 - **Issues:** Use GitHub Issues for bug reports or feature requests  
 - **PRs:** Contributions must open PRs  
 - **Guide:** Follow [`CONTRIBUTING.md`](CONTRIBUTING.md) for coding standards and
@@ -156,7 +190,7 @@ cargo build --release --features k8s --package honeybeepf-llm
 
 # Project Info
 
-## 9. Team
+## 10. Team
 
 | Name   | ID | Role       | SNS | Responsibilities                 |
 |--------|----|------------|-----|---------------------------------|
@@ -165,12 +199,12 @@ cargo build --release --features k8s --package honeybeepf-llm
 | sammiee5311 |    | Core Dev   | TBU | Feature Development             |
 | vanillaturtlechips |    | Core Dev   | TBU | CI/CD & Observability           |
 
-## 10. Tech Stack
+## 11. Tech Stack
 - **Languages:** eBPF, Kernel, Rust  
 - **Infrastructure:** Kubernetes, Helm, OpenTelemetry, Prometheus, Grafana  
 - **Communication:** Discord, GitHub Discussions  
 
-## 11. Roadmap
+## 12. Roadmap
 - **Phase 1:** CI/CD and Observability Setup  
 - **Phase 2:** Core Module Development  
 - **Phase 3:** Monitoring and Testing  
@@ -179,12 +213,12 @@ cargo build --release --features k8s --package honeybeepf-llm
 > We track roadmap execution via GitHub Projects and release multi-architecture
 > container images using `publish.sh` once CI pipelines pass.
 
-## 12. Resources & Links
+## 13. Resources & Links
 - GitHub Repository: [github.com/honeybee-studio/honeybeepf-llm](https://github.com/honeybee-studio/honeybeepf-llm)
 - Helm Charts: [`charts/honeybeepf-llm`](charts/honeybeepf-llm)
 - Governance: [`GOVERNANCE.md`](GOVERNANCE.md)
 
-## 13. Governance & Community
+## 14. Governance & Community
 - **Code of Conduct:** See [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md). Report
 	incidents privately via [GitHub Issues](https://github.com/honeybee-studio/honeybeepf-llm/issues).
 - **Decision Process:** Maintainers document proposals via Issues/Discussions
@@ -194,7 +228,7 @@ cargo build --release --features k8s --package honeybeepf-llm
 - **Membership:** Active contributors who review and merge work over two
 	consecutive releases are invited to join the maintainer group.
 
-## 14. Licensing
+## 15. Licensing
 - **Source Code:** Apache License 2.0 (`LICENSE`). See also `NOTICE`.  
 - **Documentation:** Apache License 2.0 unless otherwise noted within the document.  
 - **Third-Party Assets:** Refer to each component's directory for licensing

--- a/docs/grafana/README.md
+++ b/docs/grafana/README.md
@@ -1,0 +1,143 @@
+# HoneybeePF Grafana Dashboards
+
+Pre-built Grafana dashboards for visualizing metrics exported by the
+HoneybeePF eBPF agent via OpenTelemetry → Prometheus.
+
+## Dashboards
+
+| File | Title | Panels | Focus |
+|------|-------|:------:|-------|
+| [`honeybeepf-cost.json`](./honeybeepf-cost.json) | HoneybeePF — LLM Cost Observability | 15 | LLM API traffic, token usage, latency, cost attribution by team / pod / model |
+| [`honeybeepf-security.json`](./honeybeepf-security.json) | HoneybeePF — Security & Compliance | 11 | File access monitoring, LLM ↔ file-access correlation, per-process auditing |
+
+### Cost Observability (`honeybeepf-cost.json`)
+
+Two sections — **External LLM API** and **On-Premise LLM** — with:
+
+- Requests / minute (by team, by model)
+- Token usage / minute (prompt vs completion, by team, by model)
+- Token share pie chart
+- Latency p50 / p95 / p99
+- 5-minute summary stats (total requests, total tokens, active probes)
+- Per-pod token usage and p95 latency
+- Top 10 pods by token usage
+
+Template variables: `$datasource`, `$team`, `$pod`, `$model`.
+
+### Security & Compliance (`honeybeepf-security.json`)
+
+Three sections:
+
+- **File Access Overview** — events / minute, by namespace, top 10 accessed files
+- **Correlation & Hot Paths** — LLM ↔ file-access correlation, file access by path
+- **Summary (Last 5 Minutes)** — total events, unique files accessed, active probes
+
+Template variables: `$datasource`, `$process`.
+
+## Required Metrics
+
+These dashboards expect the following Prometheus metrics exported by the
+HoneybeePF agent. The agent emits them via OTLP to an OpenTelemetry
+Collector, which forwards them to Prometheus.
+
+### LLM metrics
+
+| Metric | Type | Labels |
+|--------|------|--------|
+| `honeybeepf_llm_requests_total` | Counter | `model`, `status`, `target_namespace`, `target_pod_name` |
+| `honeybeepf_llm_tokens_total` | Counter | `model`, `status`, `token_type` (prompt / completion), `target_namespace`, `target_pod_name` |
+| `honeybeepf_llm_latency_seconds_bucket` | Histogram | `model`, `status`, `target_namespace`, `target_pod_name` |
+
+### Security / file-access metrics
+
+| Metric | Type | Labels |
+|--------|------|--------|
+| `honeybeepf_file_access_events_total` | Counter | `filename`, `flags`, `process`, `cgroup_id`, `target_namespace`, `target_pod_name` |
+
+### Agent metrics
+
+| Metric | Type | Labels |
+|--------|------|--------|
+| `honeybeepf_active_probes` | Gauge | `probe` |
+
+> **Note:** `target_namespace` and `target_pod_name` labels are only populated
+> when the agent is built with the `k8s` feature flag (the Docker image uses
+> this by default).
+
+## Installation
+
+### Option 1 — Import via Grafana UI (simplest)
+
+1. Open Grafana → **Dashboards → New → Import**
+2. Click **Upload JSON file** and select one of the files in this directory
+3. When prompted, choose your Prometheus data source (the dashboards default
+   to a data source named `Prometheus`)
+4. Click **Import**
+
+Repeat for both dashboards.
+
+### Option 2 — ConfigMap + Grafana sidecar (Kubernetes)
+
+If your Grafana is configured with the
+[`grafana-sidecar-dashboards`](https://github.com/kiwigrid/k8s-sidecar)
+pattern (as in the official Grafana Helm chart with
+`sidecar.dashboards.enabled=true`), create a labeled ConfigMap and the
+sidecar will pick up the dashboards automatically:
+
+```bash
+kubectl -n monitoring create configmap honeybeepf-dashboards \
+  --from-file=docs/grafana/honeybeepf-cost.json \
+  --from-file=docs/grafana/honeybeepf-security.json
+
+kubectl -n monitoring label configmap honeybeepf-dashboards \
+  grafana_dashboard=1
+```
+
+Within a minute the sidecar will discover the ConfigMap, and both dashboards
+will appear in Grafana.
+
+### Option 3 — Helm values (for the HoneybeePF chart)
+
+See [`charts/honeybeepf-llm/values.yaml`](../../charts/honeybeepf-llm/values.yaml)
+for the Helm-based deployment. Dashboards can be shipped alongside the chart
+by rendering a ConfigMap from these JSON files.
+
+## Data Source Configuration
+
+Both dashboards use a `$datasource` template variable so they work with any
+Prometheus-compatible backend:
+
+- Prometheus
+- Thanos
+- Mimir
+- VictoriaMetrics
+- Cortex
+
+The default data source name is `Prometheus`. If your data source has a
+different name, select it from the **Datasource** dropdown at the top of
+the dashboard after import.
+
+## Updating the dashboards
+
+If you modify a dashboard inside Grafana and want to save the changes back:
+
+1. Open the dashboard
+2. Click the **Share** icon → **Export** tab
+3. Enable **Export for sharing externally**
+4. Click **Save to file** and overwrite the corresponding JSON here
+5. Run a quick sanity check:
+
+```bash
+jq -e . docs/grafana/honeybeepf-cost.json > /dev/null && echo ok
+grep -c VictoriaMetrics docs/grafana/*.json   # should be 0 for both
+```
+
+> **Important:** Before committing an updated JSON, make sure every
+> `"uid": "..."` under any `"datasource"` field is set to `"${datasource}"`
+> — not a hardcoded data source name. Hardcoded UIDs make the dashboard
+> unusable on anyone else's Grafana instance.
+
+## License
+
+These dashboards are distributed under the [Apache License 2.0](../../LICENSE),
+the same license as the rest of the HoneybeePF project.

--- a/docs/grafana/honeybeepf-cost.json
+++ b/docs/grafana/honeybeepf-cost.json
@@ -1,0 +1,927 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "title": "External LLM API",
+      "type": "row",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "title": "LLM Requests / min",
+      "description": "Requests per minute, by team",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 1
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisLabel": "req/min",
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "gradientMode": "scheme",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "none"
+            }
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (target_namespace) (rate(honeybeepf_llm_requests_total{target_namespace=~\"$team\", target_pod_name=~\"$pod\", model=~\"$model\"}[1m])) * 60",
+          "legendFormat": "{{ target_namespace }}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "Token Usage / min",
+      "description": "Token usage per minute, by team",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 1
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "tokens/min",
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "scheme",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "normal"
+            }
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (target_namespace) (rate(honeybeepf_llm_tokens_total{target_namespace=~\"$team\", target_pod_name=~\"$pod\", model=~\"$model\"}[1m])) * 60",
+          "legendFormat": "{{ target_namespace }}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "Token Share by Team",
+      "description": "Token usage share by team",
+      "type": "piechart",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 9
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "values": [
+            "percent",
+            "value"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi"
+        },
+        "pieType": "donut",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (target_namespace) (increase(honeybeepf_llm_tokens_total{target_namespace=~\"$team\", target_pod_name=~\"$pod\", model=~\"$model\"}[5m]))",
+          "legendFormat": "{{ target_namespace }}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "Prompt vs Completion Tokens / min",
+      "description": "Abnormal completion token spike may indicate prompt injection",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 9
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "tokens/min",
+            "drawStyle": "bars",
+            "fillOpacity": 80,
+            "lineWidth": 0,
+            "stacking": {
+              "mode": "normal"
+            }
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".*prompt.*"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".*completion.*"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (target_namespace, token_type) (rate(honeybeepf_llm_tokens_total{target_namespace=~\"$team\", target_pod_name=~\"$pod\", model=~\"$model\"}[1m])) * 60",
+          "legendFormat": "{{ target_namespace }} ({{ token_type }})",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "LLM Latency p50 / p95 / p99",
+      "description": "Response latency by team",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 9
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "seconds",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "showPoints": "never"
+          },
+          "unit": "s"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".*p99.*"
+            },
+            "properties": [
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "dash": [
+                    10,
+                    10
+                  ],
+                  "fill": "dash"
+                }
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 1
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum by (target_namespace, le) (rate(honeybeepf_llm_latency_seconds_bucket{target_namespace=~\"$team\", target_pod_name=~\"$pod\", model=~\"$model\"}[1m])))",
+          "legendFormat": "{{ target_namespace }} p50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (target_namespace, le) (rate(honeybeepf_llm_latency_seconds_bucket{target_namespace=~\"$team\", target_pod_name=~\"$pod\", model=~\"$model\"}[1m])))",
+          "legendFormat": "{{ target_namespace }} p95",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum by (target_namespace, le) (rate(honeybeepf_llm_latency_seconds_bucket{target_namespace=~\"$team\", target_pod_name=~\"$pod\", model=~\"$model\"}[1m])))",
+          "legendFormat": "{{ target_namespace }} p99",
+          "refId": "C"
+        }
+      ]
+    },
+    {
+      "title": "Token Usage by Model / min",
+      "description": "Token usage by model",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 17
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "tokens/min",
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "scheme",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "none"
+            }
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (model) (rate(honeybeepf_llm_tokens_total{target_namespace=~\"$team\", target_pod_name=~\"$pod\", model=~\"$model\"}[1m])) * 60",
+          "legendFormat": "{{ model }}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "Requests by Model / min",
+      "description": "Requests by model",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 17
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "req/min",
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "gradientMode": "scheme",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "none"
+            }
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (model) (rate(honeybeepf_llm_requests_total{target_namespace=~\"$team\", target_pod_name=~\"$pod\", model=~\"$model\"}[1m])) * 60",
+          "legendFormat": "{{ model }}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "Total Requests (5m)",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 0,
+        "y": 25
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 500
+              },
+              {
+                "color": "red",
+                "value": 1000
+              }
+            ]
+          },
+          "unit": "short"
+        }
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "sum(increase(honeybeepf_llm_requests_total{target_namespace=~\"$team\", target_pod_name=~\"$pod\", model=~\"$model\"}[5m]))",
+          "legendFormat": "Total",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "Total Tokens (5m)",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 8,
+        "y": 25
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 100000
+              },
+              {
+                "color": "red",
+                "value": 1000000
+              }
+            ]
+          },
+          "unit": "short"
+        }
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "sum(increase(honeybeepf_llm_tokens_total{target_namespace=~\"$team\", target_pod_name=~\"$pod\", model=~\"$model\"}[5m]))",
+          "legendFormat": "Total",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "Active Probes",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 16,
+        "y": 25
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        }
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "sum(honeybeepf_active_probes)",
+          "legendFormat": "Probes",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "On-Premise LLM",
+      "type": "row",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 29
+      },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "title": "Token Usage by Pod / min",
+      "description": "Self-hosted LLM — token usage per pod (GPU capacity planning)",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 30
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "tokens/min",
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "gradientMode": "scheme",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "none"
+            }
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (target_namespace, target_pod_name) (rate(honeybeepf_llm_tokens_total{target_namespace=~\"$team\", target_pod_name=~\"$pod\", model=~\"$model\"}[1m])) * 60",
+          "legendFormat": "{{ target_namespace }} / {{ target_pod_name }}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "Latency by Pod / p95",
+      "description": "Self-hosted LLM — latency per pod (rises under GPU contention)",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 30
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "seconds",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "showPoints": "never"
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by (target_namespace, target_pod_name, le) (rate(honeybeepf_llm_latency_seconds_bucket{target_namespace=~\"$team\", target_pod_name=~\"$pod\", model=~\"$model\"}[1m])))",
+          "legendFormat": "{{ target_namespace }} / {{ target_pod_name }}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "Top 10 Pods by Token Usage (5m)",
+      "description": "Self-hosted LLM — top pods by token usage",
+      "type": "bargauge",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 38
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-blues"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 10000
+              },
+              {
+                "color": "red",
+                "value": 50000
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "displayMode": "gradient",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "showUnfilled": true,
+        "minVizWidth": 0,
+        "minVizHeight": 10
+      },
+      "targets": [
+        {
+          "expr": "topk(10, sum by (target_namespace, target_pod_name) (increase(honeybeepf_llm_tokens_total{target_namespace=~\"$team\", target_pod_name=~\"$pod\", model=~\"$model\"}[5m])))",
+          "legendFormat": "{{ target_namespace }} / {{ target_pod_name }}",
+          "refId": "A"
+        }
+      ]
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 39,
+  "tags": [
+    "honeybeepf",
+    "llm",
+    "cost"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": true,
+          "text": "Prometheus",
+          "value": "Prometheus"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "type": "datasource"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(honeybeepf_llm_requests_total, target_namespace)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Team",
+        "multi": true,
+        "name": "team",
+        "options": [],
+        "query": "label_values(honeybeepf_llm_requests_total, target_namespace)",
+        "refresh": 2,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(honeybeepf_llm_requests_total{target_namespace=~\"$team\"}, target_pod_name)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Pod",
+        "multi": true,
+        "name": "pod",
+        "options": [],
+        "query": "label_values(honeybeepf_llm_requests_total{target_namespace=~\"$team\"}, target_pod_name)",
+        "refresh": 2,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(honeybeepf_llm_requests_total{target_namespace=~\"$team\"}, model)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Model",
+        "multi": true,
+        "name": "model",
+        "options": [],
+        "query": "label_values(honeybeepf_llm_requests_total{target_namespace=~\"$team\"}, model)",
+        "refresh": 2,
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-5m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "HoneybeePF - LLM Cost Observability",
+  "uid": "honeybeepf-cost",
+  "version": 1
+}

--- a/docs/grafana/honeybeepf-security.json
+++ b/docs/grafana/honeybeepf-security.json
@@ -1,0 +1,614 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "title": "File Access Overview",
+      "type": "row",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "title": "File Access Events / min",
+      "description": "Sensitive file access events — tracked by pod and file",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 1
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "events/min",
+            "drawStyle": "bars",
+            "fillOpacity": 60,
+            "lineWidth": 0,
+            "stacking": {
+              "mode": "none"
+            }
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "sum",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (target_namespace, target_pod_name, filename) (rate(honeybeepf_file_access_events_total{process=~\"$process\"}[1m])) * 60",
+          "legendFormat": "{{ target_namespace }}/{{ target_pod_name }} — {{ filename }}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "File Access by Namespace",
+      "description": "File access event count by team",
+      "type": "piechart",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 1
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "values": [
+            "percent",
+            "value"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi"
+        },
+        "pieType": "donut",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (target_namespace) (increase(honeybeepf_file_access_events_total{process=~\"$process\"}[5m]))",
+          "legendFormat": "{{ target_namespace }}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "Accessed Files (Top 10)",
+      "description": "Most-accessed sensitive files — namespace, pod, file path, process, flags",
+      "type": "table",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 9
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Access Count (5m)"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "target_namespace"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Namespace"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "target_pod_name"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Pod"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "filename"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "File Path"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "process"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Process"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "flags"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Flags"
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Access Count (5m)"
+          }
+        ]
+      },
+      "transformations": [
+        {
+          "id": "sortBy",
+          "options": {
+            "sort": [
+              {
+                "field": "Value",
+                "desc": true
+              }
+            ]
+          }
+        },
+        {
+          "id": "limit",
+          "options": {
+            "limitField": 10
+          }
+        }
+      ],
+      "targets": [
+        {
+          "expr": "topk(10, sum by (target_namespace, target_pod_name, filename, process, flags) (increase(honeybeepf_file_access_events_total{process=~\"$process\"}[5m])))",
+          "format": "table",
+          "instant": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "Correlation & Hot Paths",
+      "type": "row",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 19
+      },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "title": "LLM + File Access Correlation",
+      "description": "Correlation pattern: simultaneous LLM calls and file access in the same pod",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 20
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "events/min",
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "showPoints": "never"
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (target_namespace) (rate(honeybeepf_llm_requests_total[1m])) * 60",
+          "legendFormat": "{{ target_namespace }} (LLM calls)",
+          "refId": "A"
+        },
+        {
+          "expr": "sum by (target_namespace) (rate(honeybeepf_file_access_events_total[1m])) * 60",
+          "legendFormat": "{{ target_namespace }} (File access)",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "title": "File Access by File Path",
+      "description": "Access count per file — identify the most frequently accessed files",
+      "type": "bargauge",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 20
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-reds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "yellow",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 5
+              },
+              {
+                "color": "red",
+                "value": 10
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "displayMode": "gradient",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "showUnfilled": true
+      },
+      "targets": [
+        {
+          "expr": "topk(10, sum by (filename) (increase(honeybeepf_file_access_events_total{process=~\"$process\"}[5m])))",
+          "legendFormat": "{{ filename }}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "Summary (Last 5 Minutes)",
+      "type": "row",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 28
+      },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "title": "Total File Access Events (5m)",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 0,
+        "y": 29
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 5
+              },
+              {
+                "color": "red",
+                "value": 20
+              }
+            ]
+          },
+          "unit": "short"
+        }
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "sum(increase(honeybeepf_file_access_events_total{process=~\"$process\"}[5m]))",
+          "legendFormat": "Events",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "Unique Files Accessed (5m)",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 8,
+        "y": 29
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 3
+              },
+              {
+                "color": "red",
+                "value": 8
+              }
+            ]
+          },
+          "unit": "short"
+        }
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "count(count by (filename) (increase(honeybeepf_file_access_events_total{process=~\"$process\"}[5m]) > 0))",
+          "legendFormat": "Files",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "Active Probes",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 16,
+        "y": 29
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        }
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "sum(honeybeepf_active_probes)",
+          "legendFormat": "Probes",
+          "refId": "A"
+        }
+      ]
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 39,
+  "tags": [
+    "honeybeepf",
+    "security",
+    "compliance"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": true,
+          "text": "Prometheus",
+          "value": "Prometheus"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "type": "datasource"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(honeybeepf_file_access_events_total, process)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Process",
+        "multi": true,
+        "name": "process",
+        "options": [],
+        "query": "label_values(honeybeepf_file_access_events_total, process)",
+        "refresh": 2,
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-5m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "HoneybeePF - Security & Compliance",
+  "uid": "honeybeepf-security",
+  "version": 1
+}


### PR DESCRIPTION
## 🚀 **Pull Request**

### **Summary**

Add pre-built Grafana dashboards for HoneybeePF and document them in the repo.

Two dashboards are included under [`docs/grafana/`](docs/grafana/):

- **HoneybeePF — LLM Cost Observability** (`honeybeepf-cost.json`, 15 panels) — requests, token usage, latency, and cost attribution by team / pod / model, with sections for external LLM APIs and on-premise LLMs.
- **HoneybeePF — Security & Compliance** (`honeybeepf-security.json`, 11 panels) — file access monitoring, LLM ↔ file-access correlation, and per-process auditing.

A new section `## 7. Grafana Dashboards` is added to the root `README.md` (with subsequent sections renumbered 8–15), and `docs/grafana/README.md` documents required metrics, template variables, and installation options.

Files added:
- `docs/grafana/honeybeepf-cost.json`
- `docs/grafana/honeybeepf-security.json`
- `docs/grafana/README.md`

---

### **Additional Notes**

- **Datasource is templated.** Both dashboards use a `$datasource` Grafana template variable (default: `Prometheus`) so they work with any Prometheus-compatible backend — Prometheus, Thanos, Mimir, VictoriaMetrics, Cortex. No hardcoded datasource UIDs remain (verified with `grep`).
- **Dashboards were extracted from a running cluster** (ConfigMap `honeybeepf-grafana-dashboard` in the `monitoring` namespace of the team k3s/multipass cluster) and then cleaned up for general use.

---

### ** Tests **

- no tests needed
